### PR TITLE
Fixes console script bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
     install_requires=requirements,
     entry_points={
         'console_scripts': [
-            'subsync = ffsubsync:main'
-            'ffsubsync = ffsubsync:main'
+            'subsync=ffsubsync:main'
+            'ffsubsync=ffsubsync:main'
         ],
     },
     license='MIT',


### PR DESCRIPTION
Removed spaces in console_scripts array as they cause the user to have to call "subsync\ \=\ ffsubsync\:mainffsubsync" instead of "subsync".