### PR TITLE
Transfer info headers on ass files

### DIFF
--- a/ffsubsync/generic_subtitles.py
+++ b/ffsubsync/generic_subtitles.py
@@ -96,6 +96,7 @@ class GenericSubtitlesFile(object):
         self._sub_format = sub_format
         self._encoding = encoding
         self._styles = kwargs.pop('styles', None)
+        self._info = kwargs.pop('info', None)
 
     def set_encoding(self, encoding):
         if encoding != 'same':
@@ -120,6 +121,10 @@ class GenericSubtitlesFile(object):
     def styles(self):
         return self._styles
 
+    @property
+    def info(self):
+        return self._info
+
     def gen_raw_resolved_subs(self):
         for sub in self.subs_:
             yield sub.resolve_inner_timestamps()
@@ -134,7 +139,8 @@ class GenericSubtitlesFile(object):
             offset_subs,
             sub_format=self.sub_format,
             encoding=self.encoding,
-            styles=self.styles
+            styles=self.styles,
+            info=self.info
         )
 
     def write_file(self, fname):
@@ -150,6 +156,7 @@ class GenericSubtitlesFile(object):
             ssaf = pysubs2.SSAFile()
             ssaf.events = subs
             ssaf.styles = self.styles
+            ssaf.info = self.info
             to_write = ssaf.to_string(out_format)
         else:
             raise NotImplementedError('unsupported output format: %s' % out_format)

--- a/ffsubsync/subtitle_parser.py
+++ b/ffsubsync/subtitle_parser.py
@@ -101,7 +101,8 @@ class GenericSubtitleParser(SubsMixin, TransformerMixin):
                                      start_seconds=self.start_seconds),
                     sub_format=self.sub_format,
                     encoding=encoding,
-                    styles=parsed_subs.styles if isinstance(parsed_subs, pysubs2.SSAFile) else None
+                    styles=parsed_subs.styles if isinstance(parsed_subs, pysubs2.SSAFile) else None,
+                    info=parsed_subs.info if isinstance(parsed_subs, pysubs2.SSAFile) else None
                 )
                 self.fit_fname = '<stdin>' if fname is None else fname
                 if len(encodings_to_try) > 1:

--- a/ffsubsync/subtitle_transformers.py
+++ b/ffsubsync/subtitle_transformers.py
@@ -48,7 +48,8 @@ class SubtitleScaler(SubsMixin, TransformerMixin):
             scaled_subs,
             sub_format=subs.sub_format,
             encoding=subs.encoding,
-            styles=subs.styles
+            styles=subs.styles,
+            info=subs.info
         )
         return self
 


### PR DESCRIPTION
ASS info headers are currently not preserved when syncing ass files. This is annoying because sometimes these headers are very important to read anything.