### PR TITLE
Fix setup.py warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ tag_prefix =
 parentdir_prefix = ffsubsync-
 
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Fix the warning:
`/usr/lib/python3.9/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead`