### PR TITLE
Passing ignore_errors=True to srt.parse + displaying stack traces in case of exceptions raised

### DIFF
--- a/ffsubsync/ffsubsync.py
+++ b/ffsubsync/ffsubsync.py
@@ -216,11 +216,11 @@ def try_sync(
                 )
     except FailedToFindAlignmentException as e:
         sync_was_successful = False
-        logger.error(e)
+        logger.exception(e)
     except Exception as e:
         exc = e
         sync_was_successful = False
-        logger.error(e)
+        logger.exception(e)
     else:
         result["offset_seconds"] = offset_seconds
         result["framerate_scale_factor"] = scale_step.scale_factor

--- a/ffsubsync/subtitle_parser.py
+++ b/ffsubsync/subtitle_parser.py
@@ -88,7 +88,7 @@ class GenericSubtitleParser(SubsMixin, TransformerMixin):
             try:
                 decoded_subs = subs.decode(encoding, errors="replace").strip()
                 if self.sub_format == "srt":
-                    parsed_subs = srt.parse(decoded_subs)
+                    parsed_subs = srt.parse(decoded_subs, ignore_errors=True)
                 elif self.sub_format in ("ass", "ssa", "sub"):
                     parsed_subs = pysubs2.SSAFile.from_string(decoded_subs)
                 else:


### PR DESCRIPTION
Some `.srt` files I found do not contain any initial index for the first block,
which means that, strictly speaking, they have an incorrect format.
However they seem quite common, and I thought your awesome CLI could support them.

I initially thought about fixing this upstream, in the `srt` lib: [#81](https://github.com/cdown/srt/pull/81)
But as can be seen in this issue, a simple solution is to pass `ignore_errors=True` to `srt.parse()`.

This PR also makes `ffs` display stack traces in case of exceptions raised in `ffsubsync.py: try_sync()` (_cf._ [this SO answer](https://stackoverflow.com/a/5191885/636849)):
in this case, I couldn't have found the underlying issue without them.