### PR TITLE
Drop external argparse dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-argparse
 auditok==0.1.5
 cchardet
 ffmpeg-python


### PR DESCRIPTION
argparse has been part of the python stdlib since [2.7][0] & [3.2][1],
which [reached end-of-life on 2020/01/01 and 2016/02/20, respectively][2].
It can safely be used without being specified as an external dependency.

[0]: https://docs.python.org/2/library/argparse.html
[1]: https://docs.python.org/3/library/argparse.html
[2]: https://devguide.python.org/devcycle/

### Why can't we just keep it?

Including this dependency causes `pip`
to always reinstall the (superfluous) library
whenever upgrading ffsubsync:

    $ pip install --upgrade ffsubsync
    ...
    Collecting argparse
      Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
    ...

In practice, even though this package is installed,
`import argparse` always uses the stdlib version instead:

    $ python -c "import argparse; print(argparse)"
    <module 'argparse' from '~/.pyenv/versions/3.10.2/lib/python3.10/argparse.py'>

This is not strictly a problem, but rather an annoyance.