### PR TITLE
fix: don't report sync as successful if best score is in negatives

### DIFF
--- a/ffsubsync/ffsubsync.py
+++ b/ffsubsync/ffsubsync.py
@@ -178,6 +178,8 @@ def try_sync(
                     reference_pipe.transform(args.reference),
                     srt_pipes,
                 )
+            if best_score < 0:
+                sync_was_successful = False
             logger.info("...done")
             offset_seconds = (
                 offset_samples / float(SAMPLE_RATE) + args.apply_offset_seconds


### PR DESCRIPTION
This is easy to reproduce. Try using an input subtitle file that is not related to the video. Score is reported as negative while `sync_was_successful` is still reported as true. 

`skip_sync` is untouched. So if `skip_sync` is true (which means best score would be 0), `sync_was_successful` will still report as true.

PS: sorry for this being such a crude PR. I don't usually work in python and I couldn't come up with a test to add. I would happily take up the feedback to improve the PR if you give any.

@morpheus65535 please weigh in if you feel otherwise.