### PR TITLE
Turn on Audio Sync for audio extraction process

### DIFF
--- a/ffsubsync/speech_transformers.py
+++ b/ffsubsync/speech_transformers.py
@@ -367,6 +367,8 @@ class VideoSpeechTransformer(TransformerMixin):
                 "1",
                 "-acodec",
                 "pcm_s16le",
+                "-af",
+                "aresample=async=1",
                 "-ar",
                 str(self.frame_rate),
                 "-",


### PR DESCRIPTION
Please see the original MR here https://github.com/morpheus65535/bazarr/pull/2648


# Problem description
- I used Whisper AI and recognized that the subtitles generated didn't have the correct timestamps, especially near the end of the video.

# Cause
1. The video files I'm using have some corrupted frames. 
2. ffmpeg try to "skip" these frames, causing the duration of the extracted audio to be significantly shorter than the original video duration.

# Solution
- Turning on audio sync to make the extracted audio matches the video timestamps.

# Screenshots

## Original command
```bash
ffmpeg  -i input.mp4  -acodec pcm_s16le -ac 1 -ar 16000 -f s16le output.wav 
```
[ffmpeg-before.log](https://github.com/user-attachments/files/16831254/ffmpeg-before.log)


Imported to Audacity, only shows the duration of 22m52s532ms. The video duration is 22m59s960ms. This means subtitles will be shifted by almost 7 seconds ahead.

<img width="1292" alt="Screenshot 2024-09-01 at 5 23 34 PM" src="https://github.com/user-attachments/assets/97a23497-c70a-4ea4-bd7f-5aa87306bf65">

<img width="1292" alt="Screenshot 2024-09-01 at 5 24 23 PM" src="https://github.com/user-attachments/assets/1a42c609-43e8-4f6b-ad29-2f0aea6620c5">




## Updated command
```bash
ffmpeg  -i input.mp4  -acodec pcm_s16le -ac 1 -ar 16000 -f s16le -af aresample=async=1 output.wav 
```

[ffmpeg-after.log](https://github.com/user-attachments/files/16831255/ffmpeg-after.log)

Audacity now shows the duration of 22m59s349ms, which is approximately the original video duration of 22m59s960ms

<img width="1292" alt="Screenshot 2024-09-01 at 5 28 37 PM" src="https://github.com/user-attachments/assets/88fee8d5-25a8-4a8b-9a62-164e809529d1">
