### PR TITLE
Add support for the WebVTT format.

### DIFF
--- a/ffsubsync/generic_subtitles.py
+++ b/ffsubsync/generic_subtitles.py
@@ -139,7 +139,7 @@ class GenericSubtitlesFile:
         else:
             out_format = os.path.splitext(fname)[-1][1:]
         subs = list(self.gen_raw_resolved_subs())
-        if self._sub_format in ("ssa", "ass"):
+        if self._sub_format in ("ssa", "ass", "vtt"):
             ssaf = pysubs2.SSAFile()
             ssaf.events = subs
             if self._styles is not None:
@@ -149,7 +149,7 @@ class GenericSubtitlesFile:
             if self._fonts_opaque is not None:
                 ssaf.fonts_opaque = self._fonts_opaque
             to_write = ssaf.to_string(out_format)
-        elif self._sub_format == "srt" and out_format in ("ssa", "ass"):
+        elif self._sub_format == "srt" and out_format in ("ssa", "ass", "vtt"):
             to_write = pysubs2.SSAFile.from_string(srt.compose(subs)).to_string(
                 out_format
             )

--- a/ffsubsync/subtitle_parser.py
+++ b/ffsubsync/subtitle_parser.py
@@ -116,7 +116,7 @@ class GenericSubtitleParser(SubsMixin, TransformerMixin):
                     parsed_subs = srt.parse(
                         decoded_subs, ignore_errors=not self._strict
                     )
-                elif self.sub_format in ("ass", "ssa", "sub"):
+                elif self.sub_format in ("ass", "ssa", "sub", "vtt"):
                     parsed_subs = pysubs2.SSAFile.from_string(decoded_subs)
                 else:
                     raise NotImplementedError(


### PR DESCRIPTION
The underlying pysubs2 packages supports WebVTT so all this does is allows "vtt" subs to be passed through both for reading and writing.