### PR TITLE
fix: pgs parser when duration is None or N/A

### DIFF
--- a/ffsubsync/speech_transformers.py
+++ b/ffsubsync/speech_transformers.py
@@ -1053,6 +1053,14 @@ def find_pgs_stream(
     return None
 
 
+# PGS "clear" (display-clear) packets are tiny, fixed-size segments (~30
+# bytes in practice); "show" packets that carry an actual bitmap are always
+# far larger. This threshold now drives both the SHOW/CLEAR classification
+# used for pairing below *and* the original size-based filtering, so it is
+# named rather than inlined.
+_PGS_CLEAR_EVENT_MAX_SIZE_BYTES: int = 50
+
+
 def _get_pgs_timings_via_ffprobe(
     fname: str,
     stream: str,
@@ -1061,13 +1069,39 @@ def _get_pgs_timings_via_ffprobe(
 ) -> Optional[List[Tuple[float, float]]]:
     """Read PGS timings from container metadata using ffprobe.
 
-    MKV stores per-packet PTS and duration for subtitle streams, so we can
-    get start/end timestamps without extracting or parsing the raw SUP binary.
-    Show events are large packets with a numeric ``duration_time``; clear events
-    are tiny (~30-byte) packets with ``duration_time=N/A``.
+    MKV stores per-packet PTS (and sometimes duration) for subtitle streams,
+    so we can usually get start/end timestamps without extracting or parsing
+    the raw SUP binary. A packet is classified as a "show" event (it carries
+    a bitmap) if its size is greater than ``_PGS_CLEAR_EVENT_MAX_SIZE_BYTES``,
+    or a "clear" event (a tiny, ~30-byte, display-clear segment with no
+    image) otherwise. Depending on how the file was muxed, two different
+    representations of a caption's on-screen interval are seen in the wild,
+    and both are supported here in a single forward pass over the (already
+    pts-ordered) packet list:
 
-    Returns a list of ``(start_seconds, end_seconds)`` tuples, or ``None`` if
-    ffprobe fails or returns no usable durations.
+    1. **Numeric duration** (typical case): a show packet carries its own
+       numeric ``duration_time``, and the interval is
+       ``(pts_time, pts_time + duration_time)`` taken directly from that
+       packet, as before.
+    2. **N/A duration, paired with a clear packet** (seen from some
+       encoders -- e.g. some remuxes report an unavailable ``duration_time``
+       for *every* PGS packet): a show packet's ``duration_time`` is
+       unavailable. Its end time instead comes from the ``pts_time`` of the
+       next clear packet that follows it. At most one such pending show is
+       tracked at a time; if a new show packet (of either representation)
+       arrives before a clear packet closes the pending one, the pending one
+       is discarded -- its end time is never guessed. Likewise, a show
+       packet that is never closed by a clear packet before end-of-stream is
+       dropped.
+
+       ``ffprobe``'s ``-of json`` writer (used here, via ``ffmpeg.probe``)
+       represents "unavailable" by omitting the ``duration_time`` key from
+       the packet object entirely, rather than emitting the string
+       ``"N/A"`` the way its text-based writers (default/compact/csv) do.
+       Both spellings are treated identically below.
+
+    Returns a list of ``(start_seconds, end_seconds)`` tuples, or ``None``
+    if ffprobe fails or no packet pairing produces a usable interval.
     """
     ffprobe_cmd = ffmpeg_bin_path(
         "ffprobe", gui_mode, ffmpeg_resources_path=ffmpeg_path
@@ -1087,22 +1121,54 @@ def _get_pgs_timings_via_ffprobe(
         return None
 
     results: List[Tuple[float, float]] = []
+    # pts_time of a show packet whose duration_time was "N/A", still
+    # awaiting a clear packet to close it. At most one is tracked at a time:
+    # a new show packet (of either representation) discards whatever was
+    # previously pending rather than carrying it forward or guessing.
+    pending_show_pts: Optional[float] = None
+
     for packet in probe_data.get("packets", []):
         pts_time_str = packet.get("pts_time")
-        duration_time_str = packet.get("duration_time")
+        # ffprobe's JSON writer omits duration_time entirely when it's
+        # unavailable (rather than writing "N/A", as its text writers do),
+        # so a missing key and an explicit "N/A" both mean the same thing
+        # here: fall through to the show/clear pairing path below.
+        duration_time_str = packet.get("duration_time", "N/A")
         size_str = packet.get("size")
-        if pts_time_str is None or duration_time_str is None or size_str is None:
-            continue
-        if duration_time_str == "N/A":
+        if pts_time_str is None or size_str is None:
             continue
         try:
             pts_time = float(pts_time_str)
-            duration_time = float(duration_time_str)
             size = int(size_str)
         except ValueError:
             continue
-        if size > 50:  # skip clear events (~30 bytes)
-            results.append((pts_time, pts_time + duration_time))
+
+        if size <= _PGS_CLEAR_EVENT_MAX_SIZE_BYTES:
+            # Clear event: never produces an interval of its own. Its only
+            # role is to close a pending N/A-duration show, if any. Its own
+            # duration_time (N/A or numeric) is irrelevant and deliberately
+            # not parsed.
+            if pending_show_pts is not None:
+                results.append((pending_show_pts, pts_time))
+                pending_show_pts = None
+            continue
+
+        # Show event.
+        if duration_time_str == "N/A":
+            # Becomes the new pending show, superseding (discarding) any
+            # earlier pending show that was never closed by a clear packet.
+            pending_show_pts = pts_time
+            continue
+
+        try:
+            duration_time = float(duration_time_str)
+        except ValueError:
+            continue
+
+        # A numeric-duration show also supersedes any still-pending
+        # N/A-duration show from earlier in the stream.
+        pending_show_pts = None
+        results.append((pts_time, pts_time + duration_time))
 
     if not results:
         return None
@@ -1120,11 +1186,15 @@ class PGSSpeechTransformer(TransformerMixin, ComputeSpeechFrameBoundariesMixin):
     or parsing the raw SUP/PCS binary at all.
 
     This transformer reads those per-packet timings via ``ffprobe`` (see
-    :func:`_get_pgs_timings_via_ffprobe`), filtering out the tiny "clear" packets
-    that carry no image, and builds the same kind of sparse binary speech signal
-    that :class:`SubtitleSpeechTransformer` produces for text subtitles: 1.0 while
-    a caption is displayed, 0.0 otherwise. That signal can then be aligned against
-    the input subtitle file by the normal ffsubsync pipeline.
+    :func:`_get_pgs_timings_via_ffprobe`). Depending on how the file was muxed, a
+    caption's end time comes either directly from its own packet's numeric
+    duration, or -- for encoders that report ``duration_time=N/A`` for every
+    packet -- from the pts_time of the tiny "clear" packet that follows it and
+    marks when the image is taken back off screen. Either way, the result is the
+    same kind of sparse binary speech signal that :class:`SubtitleSpeechTransformer`
+    produces for text subtitles: 1.0 while a caption is displayed, 0.0 otherwise.
+    That signal can then be aligned against the input subtitle file by the normal
+    ffsubsync pipeline.
 
     The reference stream may be given explicitly via ``ref_stream`` (with or
     without a leading ``0:``), or left as ``None`` to auto-detect the first

--- a/tests/test_pgs.py
+++ b/tests/test_pgs.py
@@ -63,11 +63,14 @@ def test_skips_clear_events_small_size(mock_probe, mock_bin):
 @patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
 @patch("ffsubsync.speech_transformers.ffmpeg.probe")
 def test_skips_na_duration(mock_probe, mock_bin):
-    """Packets with duration_time=N/A must be skipped."""
+    """An N/A-duration SHOW with no CLEAR before the next SHOW arrives is
+    discarded (not paired), so only the second, numeric-duration SHOW
+    produces an interval."""
     mock_probe.return_value = {
         "packets": [
-            _make_packet(1.0, None, 1000),  # N/A duration
-            _make_packet(5.0, 2.0, 900),
+            _make_packet(1.0, None, 1000),  # N/A-duration SHOW; becomes
+            # pending, then discarded when...
+            _make_packet(5.0, 2.0, 900),  # ...this numeric SHOW arrives
         ]
     }
     result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
@@ -76,12 +79,147 @@ def test_skips_na_duration(mock_probe, mock_bin):
 
 @patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
 @patch("ffsubsync.speech_transformers.ffmpeg.probe")
-def test_returns_none_when_no_usable_packets(mock_probe, mock_bin):
-    """Returns None if all packets are filtered out."""
+def test_missing_duration_time_key_treated_same_as_na(mock_probe, mock_bin):
+    """ffprobe's ``-of json`` writer (what ``ffmpeg.probe`` uses) omits the
+    ``duration_time`` key entirely when it's unavailable, rather than
+    emitting the string "N/A" the way its text-based writers do. A packet
+    missing the key altogether must be paired exactly like an explicit
+    "N/A" packet. Modeled on real packets captured from an actual PGS
+    stream via ``ffprobe -of json`` (extra fields like codec_type/pts/dts
+    included, as real packets carry them, to prove they're ignored)."""
     mock_probe.return_value = {
         "packets": [
-            _make_packet(1.0, None, 1000),  # N/A duration
-            _make_packet(2.0, 1.0, 20),  # too small
+            {
+                "codec_type": "subtitle",
+                "stream_index": 3,
+                "pts": 8008,
+                "pts_time": "8.008000",
+                "dts": 8008,
+                "dts_time": "8.008000",
+                "size": "28162",
+                "pos": "22770354",
+                "flags": "K__",
+                # no "duration_time" key at all
+            },
+            {
+                "codec_type": "subtitle",
+                "stream_index": 3,
+                "pts": 12804,
+                "pts_time": "12.804000",
+                "dts": 12804,
+                "dts_time": "12.804000",
+                "size": "30",
+                "pos": "39943227",
+                "flags": "K__",
+                # no "duration_time" key at all
+            },
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(8.008, 12.804)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_pairs_na_duration_show_with_following_clear(mock_probe, mock_bin):
+    """A SHOW packet (size > 50) with duration_time=N/A is paired with the
+    pts_time of the next CLEAR packet (size <= 50) that follows it."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(8.008, None, 28162),  # SHOW, N/A duration
+            _make_packet(12.804, None, 30),  # CLEAR, closes the show above
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(8.008, 12.804)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_pairs_multiple_alternating_na_duration_show_clear(mock_probe, mock_bin):
+    """Multiple alternating SHOW/CLEAR N/A pairs each produce their own
+    correctly-ordered interval."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(8.008, None, 28162),
+            _make_packet(12.804, None, 30),
+            _make_packet(14.723, None, 9212),
+            _make_packet(21.647, None, 30),
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(8.008, 12.804), (14.723, 21.647)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_unmatched_trailing_na_duration_show_is_dropped(mock_probe, mock_bin):
+    """A trailing N/A-duration SHOW with no CLEAR ever following it is
+    dropped; it must not corrupt or suppress interval(s) already found."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(8.008, None, 28162),
+            _make_packet(12.804, None, 30),
+            _make_packet(14.723, None, 9212),  # never closed by a CLEAR
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(8.008, 12.804)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_returns_none_for_lone_unmatched_na_duration_show(mock_probe, mock_bin):
+    """A single N/A-duration SHOW packet with no CLEAR anywhere in the
+    stream produces no usable interval."""
+    mock_probe.return_value = {"packets": [_make_packet(1.0, None, 1000)]}
+    assert _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0") is None
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_second_of_two_consecutive_na_duration_shows_wins(mock_probe, mock_bin):
+    """When two N/A-duration SHOW packets appear back-to-back with no CLEAR
+    between them, the first is discarded (not carried forward or guessed)
+    and only the second pairs with the CLEAR that eventually follows."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(1.0, None, 1000),  # discarded: superseded below
+            _make_packet(2.0, None, 1200),  # this one pairs with the clear
+            _make_packet(3.0, None, 30),  # CLEAR
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(2.0, 3.0)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_mixed_numeric_and_na_duration_packets(mock_probe, mock_bin):
+    """A single packet list may mix the legacy numeric-duration SHOW
+    representation with the N/A-duration SHOW+CLEAR pairing representation;
+    both must produce correct, correctly-ordered intervals."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(1.0, 2.5, 1000),  # numeric SHOW -> (1.0, 3.5)
+            _make_packet(8.008, None, 28162),  # N/A SHOW
+            _make_packet(12.804, None, 30),  # CLEAR -> (8.008, 12.804)
+            _make_packet(20.0, 1.5, 900),  # numeric SHOW -> (20.0, 21.5)
+        ]
+    }
+    result = _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0")
+    assert result == [(1.0, 3.5), (8.008, 12.804), (20.0, 21.5)]
+
+
+@patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
+@patch("ffsubsync.speech_transformers.ffmpeg.probe")
+def test_returns_none_when_no_usable_packets(mock_probe, mock_bin):
+    """Returns None if no packet pairing ever produces a usable interval --
+    e.g. every packet is CLEAR-sized, so no SHOW is ever pending to close."""
+    mock_probe.return_value = {
+        "packets": [
+            _make_packet(1.0, None, 20),  # CLEAR-sized; no pending show
+            _make_packet(2.0, 1.0, 25),  # CLEAR-sized; no pending show
         ]
     }
     assert _get_pgs_timings_via_ffprobe("test.mkv", "0:s:0") is None
@@ -104,12 +242,14 @@ def test_returns_none_when_ffprobe_raises(mock_probe, mock_bin):
 @patch("ffsubsync.speech_transformers.ffmpeg_bin_path", return_value="ffprobe")
 @patch("ffsubsync.speech_transformers.ffmpeg.probe")
 def test_skips_packets_with_missing_fields(mock_probe, mock_bin):
-    """Packets missing any required field are silently skipped."""
+    """Packets missing pts_time or size (truly required -- unlike
+    duration_time, which may legitimately be absent, see
+    test_missing_duration_time_key_treated_same_as_na) are silently
+    skipped."""
     mock_probe.return_value = {
         "packets": [
+            {"duration_time": "2.0", "size": "1000"},  # missing pts_time
             {"pts_time": "1.0", "duration_time": "2.0"},  # missing size
-            {"pts_time": "3.0", "size": "500"},  # missing duration_time
-            {"duration_time": "1.0", "size": "500"},  # missing pts_time
             _make_packet(10.0, 1.0, 200),  # valid
         ]
     }


### PR DESCRIPTION
Fix PGS reference sync failing on streams with N/A packet durations

Some valid Matroska PGS streams report every packet's duration_time as unavailable and instead encode each caption's duration as a pair of packets: a large "show" packet followed later by a tiny "clear" packet. _get_pgs_timings_via_ffprobe only understood packets with a numeric duration_time, so it discarded every packet in these streams and raised ValueError: Failed to get PGS timings via ffprobe... even though the stream was completely valid.

There was a second, less obvious issue underneath: ffmpeg.probe() always requests JSON output, and ffprobe's JSON writer omits the duration_time key entirely when it's unavailable rather than writing the string "N/A" (only its text-based writers do that). The existing code's field-presence check treated a missing key as a malformed packet and skipped it, so this case wasn't reachable even after fixing the pairing logic.

Fix: the parser now does a single forward pass, tracking at most one pending "show" packet waiting on a "clear" packet to close it (via the existing size heuristic - large vs. ~30 bytes). A show packet's duration is either read directly (existing numeric case) or resolved from the next clear packet's timestamp (new case), treating a missing duration_time key the same as an explicit "N/A". A show packet that's never closed by a clear packet is dropped rather than assigned a guessed duration.

I've updated tests to prevent regressions for this in the future. 

Example of the error I was getting:
```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "c:\users\somemachine\.local\bin\ffs.exe\__main__.py", line 5, in <module>
  File "C:\Users\somemachine\pipx\venvs\ffsubsync\Lib\site-packages\ffsubsync\ffsubsync.py", line 1196, in main
    return run(parser)["retval"]
           ^^^^^^^^^^^
  File "C:\Users\somemachine\pipx\venvs\ffsubsync\Lib\site-packages\ffsubsync\ffsubsync.py", line 809, in run
    sync_was_successful = _run_impl(
                          ^^^^^^^^^^
  File "C:\Users\somemachine\pipx\venvs\ffsubsync\Lib\site-packages\ffsubsync\ffsubsync.py", line 735, in _run_impl
    reference_pipe.fit(args.reference)
  File "C:\Users\somemachine\pipx\venvs\ffsubsync\Lib\site-packages\ffsubsync\sklearn_shim.py", line 255, in fit
    self._final_estimator.fit(Xt, y, **fit_params)
  File "C:\Users\somemachine\pipx\venvs\ffsubsync\Lib\site-packages\ffsubsync\speech_transformers.py", line 1175, in fit
    raise ValueError(
ValueError: Failed to get PGS timings via ffprobe for stream 0:s:0 from SOMEFILENAME
```